### PR TITLE
fixed stepping of pointer to avoid re-parsing last bytes of settings

### DIFF
--- a/src/LiveScanClient/liveScanClient.cpp
+++ b/src/LiveScanClient/liveScanClient.cpp
@@ -509,6 +509,7 @@ void LiveScanClient::HandleSocket()
 			i += 1;
 
 			m_iCompressionLevel = *(int*)(received.c_str() + i);
+			i += sizeof(int);
 			if (m_iCompressionLevel > 0)
 				m_bFrameCompression = true;
 			else


### PR DESCRIPTION
Last bytes of settings data were re-parsed as separate commands and it caused the client to capture some frames right after connecting.